### PR TITLE
fix typo on project structure naming

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,4 @@
-﻿using DotNet.Docker.scr;
+﻿using DotNet.Docker.src;
 using System;
 class Program {
 	static void Main(string[] args)

--- a/src/Help.cs
+++ b/src/Help.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace DotNet.Docker.scr
+namespace DotNet.Docker.src
 {
 	internal class Help
 	{

--- a/src/Statistics.cs
+++ b/src/Statistics.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace DotNet.Docker.scr
+namespace DotNet.Docker.src
 {
 	internal class Statistics
 	{

--- a/test/StatisticsTests.cs
+++ b/test/StatisticsTests.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Linq;
 using NUnit.Framework.Internal;
-using DotNet.Docker.scr;
+using DotNet.Docker.src;
 
 namespace DotNet.Docker.test
 {


### PR DESCRIPTION
Rename ```scr``` to ```src``` wherever needed.